### PR TITLE
Make it possible to pass project path

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
 
 var path = require('path');
 
-module.exports = function version(shaLength, projectPath) {
-  if (projectPath == null) {
-    projectPath = process.cwd();
-  }
+module.exports = function version(shaLength, root) {
+
+  var projectPath = root || process.cwd();
+
   var packageVersion  = require(path.join(projectPath, 'package.json')).version;
 
   if (packageVersion.indexOf('+') > -1) {


### PR DESCRIPTION
For **ember-cli-app-version**,  @stefanpenner [suggested to read package.json from root instead of current working directory](https://github.com/taras/ember-cli-app-version/issues/3). This PR makes it possible to pass a path to the project. I will use this to pass relative project path when integrating to my library. 
