### PR TITLE
Use tag if present.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,16 @@
 'use strict';
 
-var path = require('path');
+var path       = require('path');
+var getGitInfo = require('git-repo-info');
 
 module.exports = function version(shaLength, root) {
-
   var projectPath = root || process.cwd();
 
-  var packageVersion  = require(path.join(projectPath, 'package.json')).version;
-
-  if (packageVersion.indexOf('+') > -1) {
-    if (shaLength == null){
-      shaLength = 8;
-    }
-    var info = require('git-repo-info')();
-    return packageVersion + '.' + info.sha.slice(0, shaLength);
-  } else {
-    return packageVersion;
+  var info = getGitInfo();
+  if (info.tag) {
+    return info.tag;
   }
+
+  var packageVersion  = require(path.join(projectPath, 'package.json')).version;
+  return packageVersion + '.' + info.sha.slice(0, shaLength || 8);
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "git-repo-info": "1.0.2"
+    "git-repo-info": "1.0.3"
   },
   "author": "Miguel Camba",
   "license": "MIT"


### PR DESCRIPTION
The logic is:

* If this commit is tagged, return the tag.
* If this commit is not tagged, return the version specified in
  package.json plus the SHA at the end (joined with the '+' sign)