### PR TITLE
Update to 1.0.4 of git-repo-info.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "git-repo-info": "1.0.3"
+    "git-repo-info": "^1.0.4"
   },
   "author": "Miguel Camba",
   "license": "MIT"


### PR DESCRIPTION
The initial tag support only checked `.git/refs/packed-refs`, which will only contain tags that have been packed via `git pack-refs` ([see here](https://www.kernel.org/pub/software/scm/git/docs/git-pack-refs.html)).

By default tags are stored in `.git/refs/tags/` with a separate file for each tag (contents is the SHA).

See: https://github.com/rwjblue/git-repo-info/pull/2

---

Also, use permissive versioning since git-repo-info is 1.x (and adheres to SemVer).