### PR TITLE
Fallback on branch name if package defines no version

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,15 @@ module.exports = function version(shaLength, root) {
 
   var packageVersion  = require(path.join(projectPath, 'package.json')).version;
   var sha = info.sha || '';
+  var prefix;
 
-  return packageVersion + '.' + sha.slice(0, shaLength || 8);
+  if (packageVersion != null) {
+    prefix = packageVersion;
+  } else if (info.branch) {
+    prefix = info.branch;
+  } else {
+    prefix = 'DETACHED_HEAD';
+  }
+
+  return prefix + '.' + sha.slice(0, shaLength || 8);
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+/* jshint node:true, eqnull:true */
+
 'use strict';
 
 var path       = require('path');


### PR DESCRIPTION
As I'm sure you know, this package is used by [`ember-cli-app-version`](https://github.com/embersherpa/ember-cli-app-version/blob/master/index.js#L10) to create an ember-cli app's version. Since nothing consumes our app, we don't attempt to maintain its version in `package.json`, so the version ends up as something like `undefined.1c64f6b7`.

However, it would be useful to be able to see what branch the app was built from (since the sha is super opaque), e.g. `develop.72f1db9d`. This change defaults to using the branch name if there's no package version. Note that if HEAD is not at a branch, it still ends up returning `undefined.<sha>`, but this is better than nothing :smile: 