### PR TITLE
Use `+` to denote build specific metadata.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,5 +25,5 @@ module.exports = function version(shaLength, root) {
     prefix = 'DETACHED_HEAD';
   }
 
-  return prefix + '.' + sha.slice(0, shaLength || 8);
+  return prefix + '+' + sha.slice(0, shaLength || 8);
 };


### PR DESCRIPTION
Adhere to [SemVer spec](http://semver.org/):

> Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty. Build metadata SHOULD be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85.

Thanks to @truenorth for pointing this out.