### PR TITLE
Pass through starting root directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var getGitInfo = require('git-repo-info');
 module.exports = function version(shaLength, root) {
   var projectPath = root || process.cwd();
 
-  var info = getGitInfo();
+  var info = getGitInfo(projectPath);
   if (info.tag) {
     return info.tag;
   }


### PR DESCRIPTION
Prior to this change, calling `gitRepoVersion(10, 'some/path')` would use the `some/path/package.json` for the base version, but `process.cwd()` for the SHA portion. 

This change allows both to be rooted at the same location.