### PR TITLE
Default to github's length of sha

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,5 +25,5 @@ module.exports = function version(shaLength, root) {
     prefix = 'DETACHED_HEAD';
   }
 
-  return prefix + '+' + sha.slice(0, shaLength || 8);
+  return prefix + '+' + sha.slice(0, shaLength || 7);
 };


### PR DESCRIPTION
7 sounds almost exactly as arbitrary as 8 :)

I can add configuration in a script that uses this package, but 7 sounds like a better default in a world ruled by github.
