### PR TITLE
do not include tag prefix in version

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,17 @@ var getGitInfo = require('git-repo-info');
 
 module.exports = function version(shaLength, root) {
   var projectPath = root || process.cwd();
-
+  var packageVersion  = require(path.join(projectPath, 'package.json')).version;
   var info = getGitInfo(projectPath);
+
   if (info.tag) {
-    return info.tag;
+    if (packageVersion && info.tag.includes(packageVersion)) {
+      return packageVersion;
+    } else {
+      return info.tag;
+    }
   }
 
-  var packageVersion  = require(path.join(projectPath, 'package.json')).version;
   var sha = info.sha || '';
   var prefix;
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function version(shaLength, root) {
   var info = getGitInfo(projectPath);
 
   if (info.tag) {
-    if (packageVersion && info.tag.includes(packageVersion)) {
+    if (packageVersion && info.tag.indexOf(packageVersion) !== -1) {
       return packageVersion;
     } else {
       return info.tag;


### PR DESCRIPTION
If tag is prefixed (e.g. `v1.0.0`) the prefix should not be considered
as part of version string. Therefore a check is added for tagged commits
if the tag includes version in package.json. If so everything else from tag
is treated as a prefix (or suffix). If not tag name is returned as before.

Some examples:

| tag                 | version in package.json   | returned |
| ----------------- | --------------------------------- | ------------ |
| v1.0.0            | 1.0.0                                 | 1.0.0
| release/1.0.0 |  1.0.0                                | 1.0.0
| v1.0.0            | - none -                            | v1.0.0
| bar                | foo                                    | bar
| v1.0.0-alpha | 1.0.0                                 | 1.0.0

Fixes #11