### PR TITLE
added option for no prefix in returned version

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,5 +29,9 @@ module.exports = function version(shaLength, root) {
     prefix = 'DETACHED_HEAD';
   }
 
-  return prefix + '+' + sha.slice(0, shaLength || 8);
+  if (shaLength === 0) {
+    return prefix;
+  } else {
+    return prefix + '+' + sha.slice(0, shaLength || 8);
+  }
 };


### PR DESCRIPTION
I sometimes find it handy to get the version back without the sha suffix.  Adding an option to treat 0 shaLength as a flag to ignore the sha suffix seems easy enough.