### PR TITLE
Add support for commit date in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # git-repo-version
 
-Generates a version string based on the version specified in your package.json and the sha revision of
+Generates a version string based on the version specified in your `package.json` and the sha revision of
 the current commit/branch.
 
 ## Install
 
-Tipically you will only need to install this as a devDependency as follows"
+Typically you will only need to install this as a devDependency as follows
 
 `npm install --save-dev git-repo-version`
 
 ## Usage
 
-This plugin automatically exports a function that when called calculates return the version string with a sha of the given length (defaults to 8)
+This plugin automatically exports a function that when called calculates return the version string with a sha of the given length (defaults to 8). You can also specify second parameter to include commit date in the output `{ includeDate: true }`.
 
 ```js
 var getVersion = require('git-repo-version');
-getVersion();   // "1.5.0-beta.1+pre.a1b2c3d4"
-getVersion(10); // "1.5.0-beta.1+pre.a1b2c3d4e5"
+getVersion(); // "1.5.0-beta.1+pre.a1b2c3d4"
+getVersion({ shaLength: 10 }); // "1.5.0-beta.1+pre.a1b2c3d4e5"
+getVersion({ shaLength: 10, includeDate: true }); // "1.5.0-beta.1+pre.a1b2c3d4e5 2016-10-24T18:26:53.000Z"
 ```
 
 The way this function works is:
@@ -27,3 +28,7 @@ the SHA of the current commit at the end (p.e. `1.5.0-beta.1+pre.a1b2c3d4`)
 branch and append the SHA (p.e. `develp.a1b2c3d4`)
 * In the previous case, if your current HEAD is not a branch, it will use the string `DETACHED_HEAD`
 instead (p.e `DETACHED_HEAD.1a2b3c4d`)
+
+## Running tests
+
+Simply run `npm test`

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ This plugin automatically exports a function that when called calculates return 
 
 ```js
 var getVersion = require('git-repo-version');
-getVersion(); // "1.5.0-beta.1+pre.a1b2c3d4"
-getVersion({ shaLength: 10 }); // "1.5.0-beta.1+pre.a1b2c3d4e5"
-getVersion({ shaLength: 10, includeDate: true }); // "1.5.0-beta.1+pre.a1b2c3d4e5 2016-10-24T18:26:53.000Z"
+getVersion(); // "1.5.0+a1b2c3d4"
+getVersion({ shaLength: 10 }); // "1.5.0+a1b2c3d4e5"
+getVersion({ shaLength: 10, includeDate: true }); // "1.5.0+a1b2c3d4e5 2016-10-24T18:26:53.000Z"
+getVersion({ shaLength: 0, includeDate: true }); // "1.5.0 2016-10-24T18:26:53.000Z"
 ```
 
 The way this function works is:

--- a/index.js
+++ b/index.js
@@ -29,5 +29,5 @@ module.exports = function version(options) {
 
   var authorDate = includeDate ? ' ' + info.authorDate : '';
 
-  return prefix + '+' + sha.slice(0, shaLength || 8) + authorDate;
+  return prefix + '+' + sha + authorDate;
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var getGitInfo = require('git-repo-info');
 
 module.exports = function version(options) {
   options = options || {};
-  var shaLength = options.shaLength || 8;
+  var shaLength = options.shaLength != null ? options.shaLength : 8;
   var includeDate = options.includeDate || false;
   var projectPath = options.projectPath || process.cwd();
   var info = getGitInfo(projectPath);
@@ -24,10 +24,12 @@ module.exports = function version(options) {
     prefix = 'DETACHED_HEAD';
   }
 
-  var sha = info.sha ? info.sha : '';
-  sha = sha.substring(0, shaLength);
+  var sha = '';
+  if (shaLength > 0 && info.sha) {
+    sha = '+' +  info.sha.substring(0, shaLength);
+  }
 
   var authorDate = includeDate ? ' ' + info.authorDate : '';
 
-  return prefix + '+' + sha + authorDate;
+  return prefix + sha + authorDate;
 };

--- a/index.js
+++ b/index.js
@@ -5,23 +5,18 @@
 var path       = require('path');
 var getGitInfo = require('git-repo-info');
 
-module.exports = function version(shaLength, root) {
-  var projectPath = root || process.cwd();
-  var packageVersion  = require(path.join(projectPath, 'package.json')).version;
+module.exports = function version(options) {
+  options = options || {};
+  var shaLength = options.shaLength || 8;
+  var includeDate = options.includeDate || false;
+  var projectPath = options.projectPath || process.cwd();
   var info = getGitInfo(projectPath);
+  var packageVersion  = require(path.join(projectPath, 'package.json')).version;
 
-  if (info.tag) {
-    if (packageVersion && info.tag.indexOf(packageVersion) !== -1) {
-      return packageVersion;
-    } else {
-      return info.tag;
-    }
-  }
-
-  var sha = info.sha || '';
   var prefix;
-
-  if (packageVersion != null) {
+  if (info.tag && info.tag.includes(packageVersion)) {
+    prefix = info.tag;
+  } else if (packageVersion) {
     prefix = packageVersion;
   } else if (info.branch) {
     prefix = info.branch;
@@ -29,5 +24,10 @@ module.exports = function version(shaLength, root) {
     prefix = 'DETACHED_HEAD';
   }
 
-  return prefix + '+' + sha.slice(0, shaLength || 8);
+  var sha = info.sha ? info.sha : '';
+  sha = sha.substring(0, shaLength);
+
+  var authorDate = includeDate ? ' ' + info.authorDate : '';
+
+  return prefix + '+' + sha.slice(0, shaLength || 8) + authorDate;
 };

--- a/package.json
+++ b/package.json
@@ -1,13 +1,21 @@
 {
   "name": "git-repo-version",
-  "version": "0.4.1",
+  "version": "1.0.0",
+  "description": "Generates a version string based on the version specified in your package.json and the sha revision of the current commit branch.",
   "repository": "https://github.com/cibernox/git-repo-version",
+  "author": "Miguel Camba",
+  "license": "MIT",
+  "main": "index.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">=6"
+  },
+  "scripts": {
+    "test": "mocha"
   },
   "dependencies": {
-    "git-repo-info": "~1.2.0"
+    "git-repo-info": "^1.4.1"
   },
-  "author": "Miguel Camba",
-  "license": "MIT"
+  "devDependencies": {
+    "mocha": "^4.0.1"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,14 @@ describe('getVersion', function () {
     assert.equal(result, expected);
   });
 
+  it('should not include sha when shaLength set to zero', function () {
+    const shaLength = 0;
+    var result = getVersion({ shaLength: shaLength });
+    var expected = packageVersion;
+
+    assert.equal(result, expected);
+  });
+
   it('should include date', function () {
     var result = getVersion({ includeDate: true });
     var revision = require('child_process').execSync('git rev-parse HEAD').toString().trim().substring(0, 8);

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,41 @@
+var assert = require('assert');
+var getVersion = require('../index.js');
+var packageVersion = require('../package.json').version;
+
+describe('getVersion', function () {
+  it('should return default output (version number + sha)', function () {
+    var result = getVersion();
+    var revision = require('child_process').execSync('git rev-parse HEAD').toString().trim().substring(0, 8);
+    var expected = packageVersion + '+' + revision;
+
+    assert.equal(result, expected);
+  });
+
+  it('should return custom sha length', function () {
+    const shaLength = 5;
+    var result = getVersion({ shaLength: shaLength });
+    var revision = require('child_process').execSync('git rev-parse HEAD').toString().trim().substring(0, 5);
+    var expected = packageVersion + '+' + revision;
+
+    assert.equal(result, expected);
+  });
+
+  it('should return full sha', function () {
+    const shaLength = 40;
+    var result = getVersion({ shaLength: shaLength });
+    var revision = require('child_process').execSync('git rev-parse HEAD').toString().trim();
+    var expected = packageVersion + '+' + revision;
+
+    assert.equal(result, expected);
+  });
+
+  it('should include date', function () {
+    var result = getVersion({ includeDate: true });
+    var revision = require('child_process').execSync('git rev-parse HEAD').toString().trim().substring(0, 8);
+    var lastCommitDate = require('child_process').execSync('git log -1 --format=%ai').toString().trim();
+    var isoDate = new Date(lastCommitDate).toISOString();
+    var expected = packageVersion + '+' + revision + ' ' + isoDate;
+
+    assert.equal(result, expected);
+  });
+});


### PR DESCRIPTION
Fixes #16 

@cibernox  I moved second parameter (`root`) into the options object. It wasn't mentioned in the README so I thought it's undocumented feature thus it shouldn't be breaking change. Let me know what do you think about it. 

Thank you