### PR TITLE
Allow tag to be used without package version

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function version(options) {
   var packageVersion  = require(path.join(projectPath, 'package.json')).version;
 
   var prefix;
-  if (info.tag && info.tag.includes(packageVersion)) {
+  if (info.tag && !(packageVersion && info.tag.includes(packageVersion))) {
     prefix = info.tag;
   } else if (packageVersion) {
     prefix = packageVersion;


### PR DESCRIPTION
This reintroduces the logic from #12.
As of #17 git tags could no longer be used as prefixes unless they also included the package version.