### PR TITLE
document behaviour for tagged commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ getVersion({ shaLength: 10, includeDate: true }); // "1.5.0+a1b2c3d4e5 2016-10-2
 getVersion({ shaLength: 0, includeDate: true }); // "1.5.0 2016-10-24T18:26:53.000Z"
 ```
 
-The way this function works is:
+The version number is determined by first valid condition:
 
-* If your app has a version number in its `package.json`, it will use that version number and append
-the SHA of the current commit at the end (p.e. `1.5.0-beta.1+pre.a1b2c3d4`)
-* If your app doesn't has a version number in the `package.json`, it will use the name of the current
-branch and append the SHA (p.e. `develp.a1b2c3d4`)
-* In the previous case, if your current HEAD is not a branch, it will use the string `DETACHED_HEAD`
-instead (p.e `DETACHED_HEAD.1a2b3c4d`)
+* If current commit is tagged and version number in app's `package.json` is not include in tag name,
+  it will use tag name.
+* If app has a version number in its `package.json`, it will use version number in `package.json`
+  and append the SHA of the current commit at the end (p.e. `1.5.0-beta.1+a1b2c3d4`).
+* If current HEAD is a branch, it will use the name of the that branch and append the SHA
+  (p.e. `develop+a1b2c3d4`).
+* It will use the string `DETACHED_HEAD` as fallback (p.e `DETACHED_HEAD+1a2b3c4d`)
 
 ## Running tests
 


### PR DESCRIPTION
This also updates doc accordingly to change from `.` to `+` as separator between version and commit hash. It was done here: https://github.com/cibernox/git-repo-version/commit/6a98a508922bf58f5d545c012e7e200f56b70aaa Seems like this part of docs wasn't updated since v0.2.0.

[ci skip]